### PR TITLE
Add CLI interface for customizable simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ simulado:
 python graficos_diarios.py
 ```
 
+## Simulación desde la línea de comandos
+
+El módulo `cli.py` permite ejecutar la simulación ajustando los parámetros
+básicos desde la terminal. Por ejemplo, para simular 30 días con 25 autobuses y
+una estación de 30 cargadores:
+
+```bash
+python cli.py --dias 30 --max-autobuses 25 --capacidad-estacion 30
+```
+
+También es posible cambiar la cantidad total de baterías o la semilla
+aleatoria:
+
+```bash
+python cli.py --total-baterias 60 --baterias-iniciales 50 --semilla 123
+```
+
 ## Ejecutar las pruebas
 
 Instala `pytest` y ejecuta las pruebas con:

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,64 @@
+import argparse
+
+import modelo
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Ejecuta la simulación de intercambio de baterías"
+    )
+    parser.add_argument(
+        "--dias", type=int, help="Duración de la simulación en días"
+    )
+    parser.add_argument(
+        "--max-autobuses", type=int, help="Cantidad de autobuses en la flota"
+    )
+    parser.add_argument("--semilla", type=int, help="Semilla aleatoria")
+    parser.add_argument(
+        "--capacidad-estacion",
+        type=int,
+        help="Cantidad de cargadores disponibles en la estación",
+    )
+    parser.add_argument(
+        "--total-baterias",
+        type=int,
+        help="Número total de baterías de la estación",
+    )
+    parser.add_argument(
+        "--baterias-iniciales",
+        type=int,
+        help="Baterías con las que inicia la estación",
+    )
+    parser.add_argument(
+        "--tiempo-ruta",
+        type=float,
+        default=4,
+        help="Duración de cada ruta antes de regresar a la estación",
+    )
+    args = parser.parse_args()
+
+    if any(v is not None for v in [args.dias, args.max_autobuses, args.semilla]):
+        modelo.param_simulacion.actualizar(
+            dias=args.dias, max_autobuses=args.max_autobuses, semilla=args.semilla
+        )
+
+    if any(
+        v is not None
+        for v in [args.capacidad_estacion, args.total_baterias, args.baterias_iniciales]
+    ):
+        modelo.param_estacion.actualizar(
+            capacidad=args.capacidad_estacion,
+            total=args.total_baterias,
+            iniciales=args.baterias_iniciales,
+        )
+
+    estacion = modelo.ejecutar_simulacion(
+        max_autobuses=modelo.param_simulacion.max_autobuses,
+        duracion=modelo.param_simulacion.duracion,
+        tiempo_ruta=args.tiempo_ruta,
+    )
+    modelo.imprimir_resultados(estacion)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cli.py` with an argparse interface to tweak simulation settings
- allow changing `ParametrosSimulacion` and `ParametrosEstacion`
- update README with command line examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f18994dac8330b94ce73aff3ca1ca