### PR TITLE
Keep GUI open after finishing simulation

### DIFF
--- a/GraficosModelo.py
+++ b/GraficosModelo.py
@@ -12,7 +12,7 @@ from parametros import ParametrosBateria
 TIEMPO_REEMPLAZO = 4 / 60  # Tiempo de intercambio de la batería en horas
 
 
-def grafico_carga_bateria():
+def grafico_carga_bateria(block: bool = True):
     """Grafica la curva de potencia de carga según el SoC."""
     bateria = ParametrosBateria()
     soc_vals = list(range(0, 91))
@@ -25,7 +25,7 @@ def grafico_carga_bateria():
     plt.title("Curva de carga de la batería")
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
 
 def _costos_para_autobuses(numero_autobuses, tiempo_ruta=4):
@@ -61,7 +61,7 @@ def costo_gas_teorico(numero_autobuses, tiempo_ruta=4):
     return energia_total * param_economicos.costo_gas_kwh
 
 
-def grafico_costos():
+def grafico_costos(block: bool = True):
     """Genera los gráficos de costos y consumo eléctrico."""
     max_autos = param_simulacion.max_autobuses
     valores = list(range(1, max_autos + 1))
@@ -75,7 +75,7 @@ def grafico_costos():
     plt.title("Costo de operación con electricidad")
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
     anterior = modelo.VERBOSE
     modelo.VERBOSE = False
@@ -91,7 +91,7 @@ def grafico_costos():
     plt.ylabel("Costo (S/./h)")
     plt.title("Costo promedio por hora de operación")
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
     plt.figure(figsize=(8, 4))
     plt.plot(valores, costos_elec, marker="o", label="Electricidad")
@@ -102,7 +102,7 @@ def grafico_costos():
     plt.legend()
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
     plt.figure(figsize=(8, 4))
     plt.plot(valores, energias_punta, marker="o", label="Hora punta")
@@ -113,10 +113,10 @@ def grafico_costos():
     plt.legend()
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
 
-def grafico_diarios():
+def grafico_diarios(block: bool = True):
     """Grafica intercambios y consumo diarios."""
     anterior = modelo.VERBOSE
     modelo.VERBOSE = False
@@ -138,7 +138,7 @@ def grafico_diarios():
     plt.title("Intercambios diarios")
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
     plt.figure(figsize=(8, 4))
     plt.plot(range(dias + 1), energia, marker="s", color="tab:orange")
@@ -147,10 +147,10 @@ def grafico_diarios():
     plt.title("Consumo diario de energía")
     plt.grid(True)
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
 
-def grafico_emisiones():
+def grafico_emisiones(block: bool = True):
     """Muestra un gráfico comparando emisiones y el ahorro total de CO2."""
     anterior = modelo.VERBOSE
     modelo.VERBOSE = False
@@ -173,7 +173,7 @@ def grafico_emisiones():
     plt.ylabel("Toneladas de CO2 por mes")
     plt.title("Comparación de emisiones mensuales")
     plt.tight_layout()
-    plt.show()
+    plt.show(block=block)
 
 
 def main():

--- a/gui.py
+++ b/gui.py
@@ -150,13 +150,13 @@ class SimulacionWindow(QtWidgets.QWidget):
         self._update_params()
         opcion = self.combo_grafico.currentText()
         if opcion == "Carga":
-            GraficosModelo.grafico_carga_bateria()
+            GraficosModelo.grafico_carga_bateria(block=False)
         elif opcion == "Costos":
-            GraficosModelo.grafico_costos()
+            GraficosModelo.grafico_costos(block=False)
         elif opcion == "Diarios":
-            GraficosModelo.grafico_diarios()
+            GraficosModelo.grafico_diarios(block=False)
         elif opcion == "Emisiones":
-            GraficosModelo.grafico_emisiones()
+            GraficosModelo.grafico_emisiones(block=False)
 
     def run_simulation(self):
         self._update_params()
@@ -188,17 +188,29 @@ class SimulacionWindow(QtWidgets.QWidget):
         self.resultados.setPlainText("\n".join(lines))
         self.boton.setEnabled(True)
         self.cancelar.setEnabled(False)
-        self.progreso.setValue(0)
+        # Mantener la barra de progreso en 100 % para indicar que la
+        # simulación finalizó correctamente.
+        self.progreso.setValue(100)
         self._worker.deleteLater()
         self._worker = None
         self._thread = None
+
+        # Mostrar automáticamente el gráfico seleccionado una vez
+        # finalizada la simulación. De esta manera los parámetros
+        # ajustados por el usuario se reflejan en la visualización
+        # sin cerrar la ventana.
+        self.mostrar_grafico()
+
+        # Asegurar que la ventana principal permanezca visible.
+        self.show()
 
 
 def main():
     app = QtWidgets.QApplication(sys.argv)
     win = SimulacionWindow()
     win.show()
-    sys.exit(app.exec_())
+    # Ejecutar la aplicación sin finalizar el proceso principal
+    app.exec_()
 
 
 if __name__ == "__main__":  # pragma: no cover - ejecuci\u00f3n manual


### PR DESCRIPTION
## Summary
- keep progress bar at 100% once simulation ends
- reopen main window in case it's hidden
- run the Qt application without sys.exit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686206dfd43c8330b5f48693ab3229e8