### PR TITLE
Fix GUI window closing

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -211,9 +211,9 @@ def main():
     app = QtWidgets.QApplication(sys.argv)
     win = SimulacionWindow()
     win.show()
-    # Ejecutar la aplicación sin finalizar el proceso principal
-    app.exec_()
+    # Ejecutar la aplicación y mantenerla abierta hasta que el usuario la cierre
+    return app.exec_()
 
 
 if __name__ == "__main__":  # pragma: no cover - ejecuci\u00f3n manual
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- keep GUI window alive by returning result of `app.exec_` and exiting with that code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862100049c08330935e4a3532c501c7