### PR TITLE
Refine battery swap timing

### DIFF
--- a/GraficosModelo.py
+++ b/GraficosModelo.py
@@ -61,7 +61,7 @@ def grafico_carga_bateria(block: bool = True):
     plt.show(block=block)
 
 
-def _costos_para_autobuses(numero_autobuses, tiempo_ruta=4):
+def _costos_para_autobuses(numero_autobuses, tiempo_ruta=37.2):
     """Devuelve costos y consumos para la cantidad dada de autobuses."""
     anterior = modelo.VERBOSE
     modelo.VERBOSE = False
@@ -87,10 +87,11 @@ def _costos_para_autobuses(numero_autobuses, tiempo_ruta=4):
     return costo_electrico, costo_gas, energia_punta, energia_fuera
 
 
-def costo_gas_teorico(numero_autobuses, tiempo_ruta=4):
+def costo_gas_teorico(numero_autobuses, tiempo_ruta=37.2):
     """Calcula el costo de operar los autobuses con gas natural."""
-    ciclos = param_simulacion.duracion / tiempo_ruta
-    energia_total = numero_autobuses * param_operacion.consumo_gas_hora * tiempo_ruta * ciclos
+    duracion = tiempo_ruta / param_operacion.velocidad_promedio
+    ciclos = param_simulacion.duracion / duracion
+    energia_total = numero_autobuses * param_operacion.consumo_gas_hora * duracion * ciclos
     return energia_total * param_economicos.costo_gas_kwh
 
 

--- a/README.md
+++ b/README.md
@@ -19,18 +19,28 @@ pip install -r requirements.txt
 
 main
 La estación cuenta con 21 cargadores y 41 baterías (33 de ellas cargadas al
-inicio).
-Durante los fines de semana la demanda de autobuses se reduce a la mitad,
-por lo que cada ruta dura ocho horas en lugar de cuatro. Las horas de entrada
-y salida se registran en formato ``hh:mm``.
+inicio). Las rutas cubren una distancia aproximada de 37.2 km. El tiempo que
+demora cada autobús depende de su velocidad promedio (30 km/h) y de un pequeño
+ajuste por el tráfico, de modo que los valores ya no se fijan en cuatro u ocho
+horas. Las horas de entrada y salida se registran en formato ``hh:mm``.
+
+La frecuencia de salida de autobuses ahora incluye variaciones
+aleatorias para reflejar la demanda real y posibles retrasos por
+congestión o incidentes. Durante las horas punta los intervalos
+promedio son de 3.5 minutos y el resto del día de 10 minutos, pero cada
+salida puede adelantarse o retrasarse unos minutos. Cada autobús toma
+una batería cargada de la reserva al iniciar su primer recorrido. Desde
+entonces la reemplaza solo si se estima que al terminar la siguiente
+vuelta quedará con menos de 20 % de carga.
 
 ## Gráfico de eficiencia operativa
 
 Ejecuta el script `tiempos_intercambio.py` para visualizar el tiempo de
 intercambio promedio de la estación según el número de autobuses. Cada vehículo
-efectúa una ruta de cuatro horas y regresa con la batería al 30‑40 % de carga para
-un nuevo intercambio. El valor mostrado incluye la espera en cola y el
-reemplazo de 4 minutos, expresado en minutos:
+cubre 37.2 km por ciclo y cambia la batería únicamente cuando se prevé que la
+próxima vuelta terminará con menos del 20 % de carga. El valor mostrado incluye
+la espera en cola y el reemplazo de
+4 minutos, expresado en minutos:
 
 ```bash
 python tiempos_intercambio.py

--- a/cli.py
+++ b/cli.py
@@ -32,8 +32,8 @@ def main():
     parser.add_argument(
         "--tiempo-ruta",
         type=float,
-        default=4,
-        help="Duración de cada ruta antes de regresar a la estación",
+        default=37.2,
+        help="Distancia de la ruta en kilómetros",
     )
     args = parser.parse_args()
 

--- a/gui.py
+++ b/gui.py
@@ -102,10 +102,10 @@ class SimulacionWindow(QtWidgets.QWidget):
         layout.addRow("Bater\u00edas iniciales", self.baterias_iniciales)
 
         self.tiempo_ruta = QtWidgets.QDoubleSpinBox()
-        self.tiempo_ruta.setRange(0.1, 24.0)
-        self.tiempo_ruta.setSingleStep(0.5)
-        self.tiempo_ruta.setValue(4.0)
-        layout.addRow("Tiempo ruta (h)", self.tiempo_ruta)
+        self.tiempo_ruta.setRange(1.0, 100.0)
+        self.tiempo_ruta.setSingleStep(1.0)
+        self.tiempo_ruta.setValue(37.2)
+        layout.addRow("Distancia ruta (km)", self.tiempo_ruta)
 
         self.progreso = QtWidgets.QProgressBar()
         self.progreso.setRange(0, 100)

--- a/modelo.py
+++ b/modelo.py
@@ -29,19 +29,26 @@ def formato_hora(horas_decimales):
     horas, minutos = divmod(horas_totales * 60, 60)
     return f"Día {dia:02} {int(horas):02}:{int(minutos):02}"
 
-def es_fin_de_semana(tiempo):
-    """Determina si la hora de simulación corresponde a fin de semana."""
-    dia_semana = int(tiempo // 24) % 7
-    return dia_semana >= 5
-
-def calcular_soc_inicial(hora_actual):
-    """Calcula el SoC inicial considerando el tráfico."""
+def duracion_y_consumo(distancia_km, hora_actual):
+    """Devuelve la duración y consumo para la distancia dada."""
     factor = trafico.factor_trafico(hora_actual)
-    if factor >= 1.3:
-        return random.uniform(10, 20)  # Tráfico muy congestionado
-    if factor >= 1.1:
-        return random.uniform(20, 30)  # Tráfico moderado
-    return random.uniform(30, 40)  # Tráfico ligero
+    ajuste = 1 + 0.2 * (factor - 1)
+    duracion = distancia_km / param_operacion.velocidad_promedio * ajuste
+    consumo = (
+        random.uniform(*param_operacion.consumo_kwh_km)
+        * distancia_km
+        * ajuste
+    )
+    return duracion, consumo
+
+
+def soc_estimado_despues(soc_actual, distancia_km, hora_actual):
+    """Calcula el SoC estimado tras la siguiente vuelta sin cambiar la batería."""
+    factor = trafico.factor_trafico(hora_actual)
+    ajuste = 1 + 0.2 * (factor - 1)
+    consumo_promedio = sum(param_operacion.consumo_kwh_km) / 2
+    consumo = consumo_promedio * distancia_km * ajuste
+    return soc_actual - consumo / param_bateria.capacidad * 100
 
 
 class EstacionIntercambio:
@@ -179,74 +186,130 @@ class EstacionIntercambio:
             self.costo_total_electrico += costo_carga
 
 
-# Procesos para simular la llegada de autobuses
-def llegada_autobuses(env, estacion, max_autobuses, tiempo_ruta=4):
-    """Genera la llegada inicial de autobuses y crea procesos cíclicos.
+# Procesos para simular la salida inicial de autobuses
+def llegada_autobuses(env, estacion, max_autobuses, tiempo_ruta=37.2):
+    """Genera la salida inicial de autobuses y crea procesos cíclicos.
 
-    Durante horas pico (7:00-9:00 y 16:00-18:00) los autobuses llegan cada
-    6 minutos. El resto del día la frecuencia es de 12 minutos.
+    ``tiempo_ruta`` indica la distancia de la ruta en kilómetros.
+    Durante horas pico (7:00-9:00 y 16:00-18:00) la frecuencia base de
+    salida es de 3.5 minutos y en el resto del día de 10 minutos. Se
+    introduce una variación aleatoria y posibles retrasos para reflejar la
+    incertidumbre en la demanda de energía.
     """
-    yield env.timeout(5)  # Los autobuses comienzan a llegar a las 5:00 AM
+    yield env.timeout(5)  # Los autobuses comienzan a salir a las 5:00 AM
     for autobuses_id in range(1, max_autobuses + 1):
         hora_actual = env.now % 24
         if 7 <= hora_actual < 9 or 16 <= hora_actual < 18:
-            intervalo = 0.1  # 6 minutos
+            intervalo_base = 3.5 / 60  # 3.5 minutos
         else:
-            intervalo = 0.2  # 12 minutos
+            intervalo_base = 10 / 60  # 10 minutos
+
+        variacion = random.uniform(
+            -param_simulacion.variacion_llegadas,
+            param_simulacion.variacion_llegadas,
+        )
+        intervalo = max(0, intervalo_base + variacion)
+        if random.random() < param_simulacion.prob_retraso:
+            intervalo += random.uniform(*param_simulacion.rango_retraso)
+
         yield env.timeout(intervalo)
         hora_actual = int(env.now % 24)
-        soc_inicial = calcular_soc_inicial(hora_actual)
         if VERBOSE:
             print(
-                f"Autobús {autobuses_id} llega a la estación en {formato_hora(env.now)} "
-                f"(Hora actual: {hora_actual}, SoC inicial: {soc_inicial:.2f}%)"
+                f"Autobús {autobuses_id} sale de la estación en {formato_hora(env.now)}"
             )
-        env.process(proceso_autobus(env, estacion, autobuses_id, soc_inicial, tiempo_ruta))
+        env.process(
+            proceso_autobus(
+                env,
+                estacion,
+                autobuses_id,
+                tiempo_ruta,
+                primera_salida=True,
+            )
+        )
 
 
 # Proceso para simular el flujo del autobús
-def proceso_autobus(env, estacion, autobuses_id, soc_inicial, tiempo_ruta):
-    """Simula un autobús que intercambia baterías y vuelve tras su ruta."""
-    hora_actual = int(env.now % 24)
+def proceso_autobus(env, estacion, autobuses_id, tiempo_ruta, primera_salida=False):
+    """Simula un autobús realizando rutas cíclicas."""
+    soc_actual = param_bateria.soc_objetivo
     while True:
-        llegada = env.now
-        ultimo_aviso = env.now
-        while len(estacion.baterias_reserva.items) <= 0:
-            if VERBOSE and env.now - ultimo_aviso >= 10 / 60:
-                print(
-                    f"Autobús {autobuses_id} espera batería desde {formato_hora(llegada)}"
-                )
-                ultimo_aviso = env.now
-            yield env.timeout(1 / 60)
+        hora_actual = int(env.now % 24)
+        estimado = soc_estimado_despues(soc_actual, tiempo_ruta, hora_actual)
+        if primera_salida or estimado < 20:
+            llegada = env.now
+            ultimo_aviso = env.now
+            while len(estacion.baterias_reserva.items) <= 0:
+                if VERBOSE and env.now - ultimo_aviso >= 10 / 60:
+                    print(
+                        f"Autobús {autobuses_id} espera batería desde {formato_hora(llegada)}"
+                    )
+                    ultimo_aviso = env.now
+                yield env.timeout(1 / 60)
 
-        with estacion.estaciones.request() as req:
-            yield req
-            tiempo_espera = env.now - llegada
-            estacion.tiempo_espera_total += tiempo_espera
-            if VERBOSE:
-                print(
-                    f"Autobús {autobuses_id} entra a la estación en {formato_hora(env.now)} "
-                    f"tras esperar {formato_hora(tiempo_espera)}"
-                )
-            yield env.process(
-                estacion.reemplazar_bateria(autobuses_id, soc_inicial, hora_actual)
-            )
+            with estacion.estaciones.request() as req:
+                yield req
+                tiempo_espera = env.now - llegada
+                estacion.tiempo_espera_total += tiempo_espera
+                if VERBOSE:
+                    if primera_salida:
+                        mensaje = "toma batería inicial"
+                    else:
+                        mensaje = "entra a la estación"
+                    print(
+                        f"Autobús {autobuses_id} {mensaje} en {formato_hora(env.now)} "
+                        f"tras esperar {formato_hora(tiempo_espera)}"
+                    )
+                _ = yield estacion.baterias_reserva.get()
+                ingreso = estacion._ingreso_reserva.pop(0)
+                estacion.tiempos_espera_baterias.append(env.now - ingreso)
+                if not primera_salida:
+                    yield estacion.baterias_descargadas.put(soc_actual)
+                    capacidad_requerida = (
+                        param_bateria.soc_objetivo - soc_actual
+                    ) / 100 * param_bateria.capacidad
+                else:
+                    capacidad_requerida = 0
+                tiempo_reemplazo = 4 / 60
+                hora_final = env.now + tiempo_reemplazo
+                if VERBOSE and not primera_salida:
+                    print(
+                        f"(SoC inicial: {soc_actual:.2f}%). Hora final: {formato_hora(hora_final)}"
+                    )
+                yield env.timeout(tiempo_reemplazo)
+                estacion.intercambios_realizados += 1
+                if not primera_salida:
+                    dia_actual = int(env.now // 24)
+                    hora_registro = formato_hora(env.now)
+                    estacion.registro_intercambios.append(
+                        (dia_actual, hora_registro, capacidad_requerida)
+                    )
+                    if 7 <= hora_actual < 9 or 18 <= hora_actual < 20:
+                        estacion.energia_punta_autobuses += capacidad_requerida
+                    else:
+                        estacion.energia_fuera_punta_autobuses += capacidad_requerida
+                    if (
+                        param_economicos.horas_punta[0]
+                        <= hora_actual
+                        < param_economicos.horas_punta[1]
+                    ):
+                        estacion.energia_punta_electrica += capacidad_requerida
+                soc_actual = param_bateria.soc_objetivo
+                primera_salida = False
 
-        # El autobús sale a su ruta y regresa con la batería descargada
-        duracion_ruta = tiempo_ruta * 2 if es_fin_de_semana(env.now) else tiempo_ruta
+        # El autobús sale a su ruta
         hora_inicio_ruta = int(env.now % 24)
-        factor = trafico.factor_trafico(hora_inicio_ruta)
+        duracion_ruta, consumo = duracion_y_consumo(tiempo_ruta, hora_inicio_ruta)
         yield env.timeout(duracion_ruta)
-        # Consumo de gas equivalente durante la ruta ajustado por el tráfico
-        energia_gas = param_operacion.consumo_gas_hora * duracion_ruta * factor
+        energia_gas = param_operacion.consumo_gas_hora * duracion_ruta * trafico.factor_trafico(hora_inicio_ruta)
         estacion.energia_total_gas += energia_gas
         estacion.costo_total_gas += energia_gas * param_economicos.costo_gas_kwh
+        soc_actual = max(0, soc_actual - consumo / param_bateria.capacidad * 100)
         hora_actual = int(env.now % 24)
-        soc_inicial = calcular_soc_inicial(hora_actual)
         if VERBOSE:
             print(
                 f"Autobús {autobuses_id} regresa a la estación en {formato_hora(env.now)} "
-                f"con SoC {soc_inicial:.2f}%"
+                f"con SoC {soc_actual:.2f}%"
             )
 
 
@@ -254,13 +317,14 @@ def proceso_autobus(env, estacion, autobuses_id, soc_inicial, tiempo_ruta):
 def ejecutar_simulacion(
     max_autobuses=param_simulacion.max_autobuses,
     duracion=param_simulacion.duracion,
-    tiempo_ruta=4,
+    tiempo_ruta=37.2,
     procesos_extra=None,
 ):
     """Ejecuta la simulación y devuelve la estación resultante.
 
-    ``tiempo_ruta`` indica la duración en horas de la ruta de cada autobús
-    antes de volver a solicitar un intercambio de batería.
+    ``tiempo_ruta`` representa la distancia en kilómetros de la ruta de cada
+    autobús antes de regresar a la estación. El tiempo real se calcula a partir
+    de esta distancia y de la velocidad promedio ajustada por el tráfico.
     """
     random.seed(param_simulacion.semilla)
     env = simpy.Environment()

--- a/parametros/operacion_bus.py
+++ b/parametros/operacion_bus.py
@@ -1,14 +1,31 @@
 class ParametrosOperacionBus:
     """Parámetros de operación del autobús."""
 
-    def __init__(self, costo_operacion_hora=50, penalizacion_espera=10,
-                 consumo_gas_hora=100):
+    def __init__(
+        self,
+        costo_operacion_hora=50,
+        penalizacion_espera=10,
+        consumo_gas_hora=100,
+        velocidad_promedio=30,
+        consumo_kwh_km=(0.9, 1.2),
+    ):
         self.costo_operacion_hora = costo_operacion_hora
         self.penalizacion_espera = penalizacion_espera
         # Energía equivalente que consumiría un autobús a gas por hora
         self.consumo_gas_hora = consumo_gas_hora
+        # Velocidad promedio del autobús en km/h
+        self.velocidad_promedio = velocidad_promedio
+        # Rango de consumo eléctrico por kilómetro recorrido
+        self.consumo_kwh_km = consumo_kwh_km
 
-    def actualizar(self, costo=None, penalizacion=None, consumo_gas=None):
+    def actualizar(
+        self,
+        costo=None,
+        penalizacion=None,
+        consumo_gas=None,
+        velocidad=None,
+        consumo_km=None,
+    ):
         """Permite modificar los parámetros de operación."""
         if costo is not None:
             self.costo_operacion_hora = costo
@@ -16,3 +33,7 @@ class ParametrosOperacionBus:
             self.penalizacion_espera = penalizacion
         if consumo_gas is not None:
             self.consumo_gas_hora = consumo_gas
+        if velocidad is not None:
+            self.velocidad_promedio = velocidad
+        if consumo_km is not None:
+            self.consumo_kwh_km = consumo_km

--- a/parametros/simulacion.py
+++ b/parametros/simulacion.py
@@ -1,19 +1,42 @@
 class ParametrosSimulacion:
     """Parámetros generales de la simulación."""
 
-    def __init__(self, dias=21, max_autobuses=20, semilla=42):
+    def __init__(
+        self,
+        dias=21,
+        max_autobuses=20,
+        semilla=42,
+        variacion_llegadas=0.05,
+        prob_retraso=0.1,
+        rango_retraso=(5 / 60, 15 / 60),
+    ):
         # La duración se ingresa en días y se convierte a horas cuando es
         # necesario ejecutar la simulación.
         self.dias = dias
         self.max_autobuses = max_autobuses
         self.semilla = semilla
+        # Variación aleatoria (+/- horas) aplicada a los intervalos base de
+        # llegada de autobuses.
+        self.variacion_llegadas = variacion_llegadas
+        # Probabilidad de sufrir un retraso adicional en el intervalo.
+        self.prob_retraso = prob_retraso
+        # Rango de la demora extra cuando ocurre un retraso.
+        self.rango_retraso = rango_retraso
 
     @property
     def duracion(self):
         """Duración de la simulación en horas."""
         return self.dias * 24
 
-    def actualizar(self, dias=None, max_autobuses=None, semilla=None):
+    def actualizar(
+        self,
+        dias=None,
+        max_autobuses=None,
+        semilla=None,
+        variacion_llegadas=None,
+        prob_retraso=None,
+        rango_retraso=None,
+    ):
         """Permite actualizar los parámetros de simulación."""
         if dias is not None:
             self.dias = dias
@@ -21,3 +44,9 @@ class ParametrosSimulacion:
             self.max_autobuses = max_autobuses
         if semilla is not None:
             self.semilla = semilla
+        if variacion_llegadas is not None:
+            self.variacion_llegadas = variacion_llegadas
+        if prob_retraso is not None:
+            self.prob_retraso = prob_retraso
+        if rango_retraso is not None:
+            self.rango_retraso = rango_retraso


### PR DESCRIPTION
## Summary
- clarify in README that buses swap batteries only if the next round would end below 20% SoC
- estimate next-trip SoC and use it to decide if a bus needs a replacement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6865d667ff7c833085820201016de692