### PR TITLE
Compute gas cost based on distance

### DIFF
--- a/GraficosModelo.py
+++ b/GraficosModelo.py
@@ -91,8 +91,14 @@ def costo_gas_teorico(numero_autobuses, tiempo_ruta=37.2):
     """Calcula el costo de operar los autobuses con gas natural."""
     duracion = tiempo_ruta / param_operacion.velocidad_promedio
     ciclos = param_simulacion.duracion / duracion
-    energia_total = numero_autobuses * param_operacion.consumo_gas_hora * duracion * ciclos
-    return energia_total * param_economicos.costo_gas_kwh
+    volumen_total = (
+        numero_autobuses
+        * param_operacion.consumo_gas_100km
+        * tiempo_ruta
+        / 100
+        * ciclos
+    )
+    return volumen_total * param_economicos.costo_gas_m3
 
 
 def grafico_costos(block: bool = True):
@@ -245,12 +251,13 @@ def grafico_inventario(block: bool = True):
         return
     _, datos = _simular_con_registro()
     horas = range(len(datos["cargadas"]))
+    dias = [h / 24 for h in horas]
 
     plt.style.use(ESTILO_MEJOR)
     plt.figure(figsize=(8, 4))
-    plt.plot(horas, datos["cargadas"], label="Cargadas")
-    plt.plot(horas, datos["descargadas"], label="Descargadas")
-    plt.xlabel("Hora de simulación")
+    plt.plot(dias, datos["cargadas"], label="Cargadas")
+    plt.plot(dias, datos["descargadas"], label="Descargadas")
+    plt.xlabel("Día de simulación")
     plt.ylabel("Número de baterías")
     plt.title("Inventario de baterías")
     plt.legend()
@@ -272,11 +279,12 @@ def grafico_cola(block: bool = True):
     for i in range(1, len(espera)):
         espera_h.append((espera[i] - espera[i - 1]) * 60)
     horas = range(len(espera_h))
+    dias = [h / 24 for h in horas]
 
     plt.style.use(ESTILO_MEJOR)
     plt.figure(figsize=(8, 4))
-    plt.plot(horas, espera_h, marker="o")
-    plt.xlabel("Hora de simulación")
+    plt.plot(dias, espera_h, marker="o")
+    plt.xlabel("Día de simulación")
     plt.ylabel("Minutos de espera nuevos")
     plt.title("Evolución de la cola de autobuses")
     plt.grid(True)
@@ -331,14 +339,15 @@ def grafico_uso_cargadores(block: bool = True):
         return
     _, datos = _simular_con_registro()
     horas = range(len(datos["cargando"]))
+    dias = [h / 24 for h in horas]
     uso = [
         c / param_estacion.capacidad_estacion * 100 for c in datos["cargando"]
     ]
 
     plt.style.use(ESTILO_MEJOR)
     plt.figure(figsize=(8, 4))
-    plt.plot(horas, uso, marker="o")
-    plt.xlabel("Hora de simulación")
+    plt.plot(dias, uso, marker="o")
+    plt.xlabel("Día de simulación")
     plt.ylabel("Uso de cargadores (%)")
     plt.title("Utilización de cargadores")
     plt.grid(True)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 
 
 main
-La estación cuenta con 21 cargadores y 41 baterías (33 de ellas cargadas al
+La estación cuenta con 21 cargadores y 41 baterías (20 de ellas cargadas al
 inicio). Las rutas cubren una distancia aproximada de 37.2 km. El tiempo que
 demora cada autobús depende de su velocidad promedio (30 km/h) y de un pequeño
 ajuste por el tráfico, de modo que los valores ya no se fijan en cuatro u ocho
@@ -82,11 +82,11 @@ según la cantidad de autobuses evaluada. De esta manera no se genera la caída 
 costos al pasar de cuatro a cinco vehículos ni la estabilización por encima de
 diez.
 
-El costo de operar con gas natural se calcula aparte empleando el consumo
-promedio de cada autobús y no depende de los valores de electricidad. Para
-estas simulaciones se considera un uso de 100 kWh por hora, lo que equivale a
-unos 200 000 kWh para una flota de veinte vehículos durante 21 días de
-operación.
+El costo de operar con gas natural se calcula aparte a partir de la distancia
+recorrida y no depende del consumo eléctrico. Cada autobús utiliza 70 m³ de gas
+por cada 100 km y el precio de venta es de S/. 1.35 por metro cúbico. Para una
+flota de veinte vehículos durante 21 días esto representa unos 26 000 m³ en
+total.
 
 Ejecuta:
 

--- a/parametros/economicos.py
+++ b/parametros/economicos.py
@@ -5,14 +5,14 @@ class ParametrosEconomicos:
         self,
         costo_punta=0.28,
         costo_normal=0.238,
-        costo_gas_kwh=0.10,
+        costo_gas_m3=1.35,
         horas_punta=(18, 23),
         factor_co2_gas=0.25,
         factor_co2_elec=0.20,
     ):
         self.costo_punta = costo_punta
         self.costo_normal = costo_normal
-        self.costo_gas_kwh = costo_gas_kwh
+        self.costo_gas_m3 = costo_gas_m3
         self.horas_punta = horas_punta
         self.factor_co2_gas = factor_co2_gas
         self.factor_co2_elec = factor_co2_elec
@@ -21,7 +21,7 @@ class ParametrosEconomicos:
         self,
         punta=None,
         normal=None,
-        gas_kwh=None,
+        gas_m3=None,
         horas=None,
         factor_gas=None,
         factor_elec=None,
@@ -31,8 +31,8 @@ class ParametrosEconomicos:
             self.costo_punta = punta
         if normal is not None:
             self.costo_normal = normal
-        if gas_kwh is not None:
-            self.costo_gas_kwh = gas_kwh
+        if gas_m3 is not None:
+            self.costo_gas_m3 = gas_m3
         if horas is not None:
             self.horas_punta = horas
         if factor_gas is not None:

--- a/parametros/estacion.py
+++ b/parametros/estacion.py
@@ -1,7 +1,7 @@
 class ParametrosEstacion:
     """Parámetros de la estación de carga."""
 
-    def __init__(self, capacidad_estacion=21, total_baterias=41, baterias_iniciales=33):
+    def __init__(self, capacidad_estacion=21, total_baterias=41, baterias_iniciales=20):
         self.capacidad_estacion = capacidad_estacion
         self.total_baterias = total_baterias
         self.baterias_iniciales = baterias_iniciales

--- a/parametros/operacion_bus.py
+++ b/parametros/operacion_bus.py
@@ -6,6 +6,7 @@ class ParametrosOperacionBus:
         costo_operacion_hora=50,
         penalizacion_espera=10,
         consumo_gas_hora=100,
+        consumo_gas_100km=70,
         velocidad_promedio=30,
         consumo_kwh_km=(0.9, 1.2),
     ):
@@ -13,6 +14,8 @@ class ParametrosOperacionBus:
         self.penalizacion_espera = penalizacion_espera
         # Energía equivalente que consumiría un autobús a gas por hora
         self.consumo_gas_hora = consumo_gas_hora
+        # Volumen de gas natural consumido por cada 100 km recorridos (m3)
+        self.consumo_gas_100km = consumo_gas_100km
         # Velocidad promedio del autobús en km/h
         self.velocidad_promedio = velocidad_promedio
         # Rango de consumo eléctrico por kilómetro recorrido
@@ -23,6 +26,7 @@ class ParametrosOperacionBus:
         costo=None,
         penalizacion=None,
         consumo_gas=None,
+        gas_100km=None,
         velocidad=None,
         consumo_km=None,
     ):
@@ -33,6 +37,8 @@ class ParametrosOperacionBus:
             self.penalizacion_espera = penalizacion
         if consumo_gas is not None:
             self.consumo_gas_hora = consumo_gas
+        if gas_100km is not None:
+            self.consumo_gas_100km = gas_100km
         if velocidad is not None:
             self.velocidad_promedio = velocidad
         if consumo_km is not None:


### PR DESCRIPTION
## Summary
- add gas volume consumption parameter and price
- calculate gas cost from distance instead of energy
- rename economic parameter to `costo_gas_m3`
- document new gas cost model in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68699a4e00588330b5e6995beebb6c76