### PR TITLE
Fix repeated peak-hour delay log

### DIFF
--- a/modelo.py
+++ b/modelo.py
@@ -179,7 +179,12 @@ class EstacionIntercambio:
                 continue
 
             hora_actual = self.env.now % 24
-            if inventario_suficiente_hasta_fin_punta(self, hora_actual):
+            if (
+                param_economicos.horas_punta[0]
+                <= hora_actual
+                < param_economicos.horas_punta[1]
+                and inventario_suficiente_hasta_fin_punta(self, hora_actual)
+            ):
                 espera = param_economicos.horas_punta[1] - hora_actual
                 if espera < 0:
                     espera += 24


### PR DESCRIPTION
## Summary
- delay battery charging only when currently in peak hours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869b5479ef48330b2d887ecc8a6f1f7